### PR TITLE
Add pkgdown site / static-docs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,8 @@
 CONTRIBUTING.md
 ^codecov\.yml$
 ^data-raw$
+
+# pkgdown-related
+^docs$
+^pkgdown$
+^pkgdown/_pkgdown\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ man/mcmcPPlot.Rd
 man/mcmcSimAve.Rd
 man/mcmcSimFD.Rd
 man/mcmcSimObs.Rd
+
+# if a pkgdown site has been locally built, don't put it on git; 
+# Travis-CI will take care of deployment
+docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,14 @@ before_install:
 
 after_success:
   - Rscript -e 'covr::codecov()'
+
+# commented for now; this will not work until Travis has the GITHUB_PAT
+# environment variable, and so will error out the builds
+#deploy:
+#  provider: pages
+#  skip_cleanup: true
+#  github_token: $GITHUB_PAT
+#  keep_history: true
+#  local_dir: docs
+#  on:
+#    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,11 @@ before_install:
 after_success:
   - Rscript -e 'covr::codecov()'
 
-# commented for now; this will not work until Travis has the GITHUB_PAT
-# environment variable, and so will error out the builds
-#deploy:
-#  provider: pages
-#  skip_cleanup: true
-#  github_token: $GITHUB_PAT
-#  keep_history: true
-#  local_dir: docs
-#  on:
-#    branch: master
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_PAT
+  keep_history: true
+  local_dir: docs
+  on:
+    branch: master

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -1,0 +1,1 @@
+destination: docs


### PR DESCRIPTION
Hello, I added the bare-bones config files, and there are some manual steps required for this to work. Hopefully I got them all right. 

1. On GitHub, generate a personal access token using the steps at https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line. This is what I did for another package:

![Screen Shot 2019-09-18 at 14 23 20](https://user-images.githubusercontent.com/1353756/65144450-148b6880-da20-11e9-962c-3224421bdda6.png)

2. On Travis-CI, from the package page for BayesPostEst > More options > Settings > Environment variables, add the token. E.g.:

![Screen Shot 2019-09-18 at 14 18 41](https://user-images.githubusercontent.com/1353756/65144628-67fdb680-da20-11e9-8075-1b15924c8bb3.png)

3. On the GitHub repo page > Settings turn on Github Pages with source set to gh-pages branch. 

![Screen Shot 2019-09-18 at 14 31 48](https://user-images.githubusercontent.com/1353756/65145033-49e48600-da21-11e9-91f9-7b862209ac80.png)

For commits after this, Travis should then start building the website and pushing it to a `gh-pages` branch. If you don't have something setup for your accounts' GitHub default page, I guess the URL should be https://ShanaScogin.github.io/BayesPostEst. 